### PR TITLE
Remove unnecessary FFmpeg options

### DIFF
--- a/src/mpeg1muxer.coffee
+++ b/src/mpeg1muxer.coffee
@@ -14,10 +14,6 @@ Mpeg1Muxer = (options) ->
     @url
     '-f'
     'mpeg1video'
-    '-b:v'
-    '800k'
-    '-r'
-    '30'
     '-'
   ], {detached: false}
 


### PR DESCRIPTION
Removed the following options as the -b:v option causes re-encoding of the video and slows down the processor, while the -r 30 specifies an output framerate of 30fps, which may be different than the input frame rate of the RTSP source and could cause erroneous warning messages from ffmpeg.

```
    '-b:v'
    '800k'
    '-r'
    '30'
```