### PR TITLE
Update videoStream.js

### DIFF
--- a/videoStream.js
+++ b/videoStream.js
@@ -122,11 +122,14 @@ VideoStream.prototype.onSocketConnect = function(socket, request) {
   socket.send(streamHeader, {
     binary: true
   })
+
+  this.emit('clientCount',this.name,this.wsServer.clients.size);
   console.log(`${this.name}: New WebSocket Connection (` + this.wsServer.clients.size + " total)")
 
   socket.remoteAddress = request.connection.remoteAddress
 
   return socket.on("close", (code, message) => {
+    this.emit('clientCount',this.name,this.wsServer.clients.size);
     return console.log(`${this.name}: Disconnected WebSocket (` + this.wsServer.clients.size + " total)")
   })
 }


### PR DESCRIPTION
Add clientCount emitter for stream

Using this we can track how many clients are connected to particular stream and it will also provide an option to stop the stream if there is no viewer.

I was having similar requirement, so i added this change, hopefully this will be helpful for others too.